### PR TITLE
Enemy AI to follow player

### DIFF
--- a/scarab-engine/src/effect/mod.rs
+++ b/scarab-engine/src/effect/mod.rs
@@ -1,0 +1,98 @@
+use std::fmt::Debug;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    types::physbox::{HasBox, PhysBox},
+    ScarabResult,
+};
+
+/// Helper structs for applying basic effects and attacks to entities
+#[cfg(feature = "effect-helpers")]
+pub mod effect_helpers;
+
+#[derive(Debug)]
+/// An effect on other entities that the scene should process on the next game tick
+pub struct PendingEffect<E> {
+    /// An optional source of the effect
+    pub source: Option<EffectSource>,
+    /// Determines which objects should be targeted by the source
+    pub target: Box<dyn EffectTarget<E>>,
+    /// Handles the logic of applying the effect
+    pub effect: Box<dyn Effect<E>>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+/// A source of an effect
+pub struct EffectSource {
+    /// The source's registry index
+    pub index: usize,
+    /// Whether or not the effect should target the source
+    pub can_target_source: bool,
+}
+
+impl EffectSource {
+    /// Checks, for the source parameters, whether the effect should be called on the source
+    pub fn should_apply_effect(&self, target_index: usize) -> bool {
+        !(!self.can_target_source && target_index == self.index)
+    }
+}
+
+impl From<(usize, bool)> for EffectSource {
+    fn from((index, can_target_source): (usize, bool)) -> Self {
+        Self {
+            index,
+            can_target_source,
+        }
+    }
+}
+
+/// Checks whether an object is targeted by an effect source
+pub trait EffectTarget<E>: Debug {
+    /// Given a potential target, returns whether it should be targeted by the effect
+    fn can_target(&mut self, potential_target: &E) -> bool;
+}
+
+impl<E: HasBox> EffectTarget<E> for PhysBox {
+    fn can_target(&mut self, potential_target: &E) -> bool {
+        self.has_overlap(potential_target.get_box())
+    }
+}
+
+/// Effects that can target other entities of type `E`
+pub trait Effect<E>: Debug {
+    /// Apply the main effect to a target entity (i.e. do damage, apply status effects, etc.)
+    /// Returns whether or not the effect needs to process on the next tick
+    fn apply_effect(&mut self, target: &mut E) -> ScarabResult<bool>;
+
+    /// Apply any necessary updates to the source of the effect
+    /// This could be animation states, draining energy or any other necessary effect
+    fn update_src(&mut self, src: &mut E) -> ScarabResult<()>;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn effect_source_always_targets_when_not_source() {
+        let source_index = 0;
+        let mut source: EffectSource = (source_index, false).into();
+
+        assert!(source.should_apply_effect(source_index + 1));
+
+        source.can_target_source = true;
+        assert!(source.should_apply_effect(source_index + 1));
+    }
+
+    #[test]
+    fn effect_source_targets_source_only_when_able() {
+        let source_index = 0;
+        let mut source: EffectSource = (source_index, false).into();
+
+        assert!(!source.should_apply_effect(source_index));
+
+        source.can_target_source = true;
+        assert!(source.should_apply_effect(source_index));
+    }
+}

--- a/scarab-engine/src/gameobject/entity/mod.rs
+++ b/scarab-engine/src/gameobject/entity/mod.rs
@@ -19,9 +19,6 @@ use crate::{
     HasBox, HasBoxMut, HasHealth, HasSolidity, HasUuid, PhysicsError, PhysicsResult, ScarabResult,
 };
 
-/// Helper structs for applying basic effects and attacks to entities
-#[cfg(feature = "effect-helpers")]
-pub mod effect_helpers;
 /// Handles the registration of entities (loading and unloading)
 pub mod registry;
 

--- a/scarab-engine/src/lib.rs
+++ b/scarab-engine/src/lib.rs
@@ -7,6 +7,8 @@
 
 /// The trait for running an app at a high level
 mod app;
+/// Controls for entity-entity interactions and effects
+pub mod effect;
 /// Common error and result types
 pub mod error;
 /// Game objects

--- a/scarab-engine/src/types/mod.rs
+++ b/scarab-engine/src/types/mod.rs
@@ -196,6 +196,15 @@ impl From<Vec2d> for Velocity {
     }
 }
 
+impl From<Point> for Velocity {
+    fn from(value: Point) -> Self {
+        Self {
+            x: value.x,
+            y: value.y,
+        }
+    }
+}
+
 /// A trait for a gameobject that has a unique identifier
 pub trait HasUuid {
     /// The object's unique identifier

--- a/scarab-example/src/entities/enemy.rs
+++ b/scarab-example/src/entities/enemy.rs
@@ -1,7 +1,15 @@
 use scarab_engine::{
-    gameobject::entity::Entity, HasBox, HasBoxMut, HasEntity, HasHealth, HasSolidity, HasUuid,
+    effect::{
+        effect_helpers::{FollowBox, TargetFirstPlayer},
+        PendingEffect,
+    },
+    gameobject::entity::Entity,
+    scene::GameTickArgs,
+    HasBox, HasBoxMut, HasEntity, HasHealth, HasSolidity, HasUuid, ScarabResult,
 };
 use serde::{Deserialize, Serialize};
+
+use super::ExampleEntities;
 
 #[derive(
     Debug, Serialize, Deserialize, HasBox, HasBoxMut, HasEntity, HasHealth, HasSolidity, HasUuid,
@@ -13,4 +21,22 @@ pub struct Enemy {
     #[has_solidity]
     #[has_uuid]
     pub entity: Entity,
+}
+
+impl Enemy {
+    pub fn game_tick(
+        &mut self,
+        this_idx: usize,
+        args: &mut GameTickArgs<ExampleEntities>,
+    ) -> ScarabResult<()> {
+        self.entity.game_tick(args)?;
+
+        args.pending_effects.push(PendingEffect {
+            source: Some((this_idx, false).into()),
+            target: Box::new(TargetFirstPlayer::default()),
+            effect: Box::new(FollowBox::default()),
+        });
+
+        Ok(())
+    }
 }

--- a/scarab-example/src/entities/mod.rs
+++ b/scarab-example/src/entities/mod.rs
@@ -100,9 +100,7 @@ impl RegisteredEntity for ExampleEntities {
     fn game_tick(&mut self, this_idx: usize, args: &mut GameTickArgs<Self>) -> ScarabResult<()> {
         match self {
             ExampleEntities::Player((player, _)) => player.game_tick(this_idx, args),
-            ExampleEntities::Enemy((enemy, _)) => {
-                enemy.entity.game_tick(args).map_err(|e| e.into())
-            }
+            ExampleEntities::Enemy((enemy, _)) => enemy.game_tick(this_idx, args),
         }
     }
 }

--- a/scarab-example/src/entities/player.rs
+++ b/scarab-example/src/entities/player.rs
@@ -1,9 +1,7 @@
 use graphics::types::Color;
 use scarab_engine::{
-    gameobject::entity::{
-        effect_helpers::{BasicAttack, Cooldown, TryAction},
-        Entity,
-    },
+    effect::effect_helpers::{BasicAttack, Cooldown, TryAction},
+    gameobject::entity::Entity,
     rendering::{
         components::progress_bar::{self, InsetPosition},
         debug::DebugView,
@@ -60,7 +58,7 @@ impl Player {
             let size = self.get_box().size();
             let _ = target_area.set_size([size.w * 2.0, size.h * 2.0].into());
             target_area.set_pos(*self.get_box().pos() - Point::from([size.w, size.h]));
-            args.pending_attacks
+            args.pending_effects
                 .push(self.attack.1.into_pending_effect(this_idx, target_area));
         }
 


### PR DESCRIPTION
kinda hijacking the attack/effect structure to do this, so a future effort would be good to generalize it away from "Effect" and into "Command" perhaps. The generalization of this structure is also potentially useful in future networked/multiplayer uses.